### PR TITLE
Update to Openfire 4.4.1

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <openfireStructure.build.dir>${project.build.directory}/${project.artifactId}-${project.version}</openfireStructure.build.dir>
         <openfireStructure.lib.dir>${openfireStructure.build.dir}/lib</openfireStructure.lib.dir>
-        <openfire.version>4.3.0</openfire.version>
+        <openfire.version>4.4.1</openfire.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.4.1</version>
     </parent>
     <groupId>org.igniterealtime.openfire.fastpath</groupId>
     <artifactId>webchat</artifactId>


### PR DESCRIPTION
Static analysis generates security related reports when using Openfire prior to 4.4.1. Even though they have no direct relationship to this code, there are no functional changes expected by upgrading to 4.4.1. Doing that will appease the static analyzer.